### PR TITLE
Adds encrypt command for sensitive parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,14 @@ your `$PATH` and run the following command:
 go get -u github.com/rafaeljusto/toglacier
 ```
 
-As this program works like a service/daemon, you should run it in background. It
-is a good practice to also add it to your system startup (you don't want your
-backup to stop working after a reboot).
+If you are thinking that is a good idea to encrypt some sensitive tool
+parameters and want to improve the security, is a good idea to replace the
+numbers of the slices in the function `passwordKey` of the `encpass.go` file for
+your random numbers. Remember to compile the tool again (`go install`).
+
+As this program can work like a service/daemon (start command), in this case you
+should run it in background. It is a good practice to also add it to your system
+startup (you don't want your backup scheduler to stop working after a reboot).
 
 ## Usage
 
@@ -62,6 +67,12 @@ There are some commands in the tool to manage the backups:
   * **list or ls**: list the current backups using a local audit file or remotly
   * **remove or rm**: remove a backup from AWS Glacier service
   * **start**: initialize the scheduler (will block forever)
+  * **encrypt or enc**: encrypt a password or secret to improve security
+
+You can improve the security by encrypting the values (use encrypt command) of
+the variables `AWS_ACCOUNT_ID`, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+The tool will detect an encrypted value when it starts with the label
+`encrypted:`.
 
 The audit file that keeps track of all backups has the format bellow. It's a
 good idea to periodically copy this audit file somewhere else, so if you lose
@@ -81,9 +92,9 @@ environments:
 ```shell
 #!/bin/sh
 
-AWS_ACCOUNT_ID="000000000000" \
-AWS_ACCESS_KEY_ID="AAAAAAAAAAAAAAAAAAAA" \
-AWS_SECRET_ACCESS_KEY="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
+AWS_ACCOUNT_ID="encrypted:DueEGILYe8OoEp49Qt7Gymms2sPuk5weSPiG6w==" \
+AWS_ACCESS_KEY_ID="encrypted:XesW4TPKzT3Cgw1SCXeMB9Pb2TssRPCdM4mrPwlf4zWpzSZQ" \
+AWS_SECRET_ACCESS_KEY="encrypted:hHHZXW+Uuj+efOA7NR4QDAZh6tzLqoHFaUHkg/Yw1GE/3sJBi+4cn81LhR8OSVhNwv1rI6BR4fA=" \
 AWS_REGION="us-east-1" \
 AWS_VAULT_NAME="backup" \
 TOGLACIER_PATH="/usr/local/important-files-1,/usr/local/important-files-2" \

--- a/aws.go
+++ b/aws.go
@@ -34,6 +34,32 @@ type awsResult struct {
 var awsGlacier glacieriface.GlacierAPI
 
 func init() {
+	var err error
+
+	awsAccessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")
+	if strings.HasPrefix(awsAccessKeyID, "encrypted:") {
+		awsAccessKeyID, err = passwordDecrypt(strings.TrimPrefix(awsAccessKeyID, "encrypted:"))
+		if err != nil {
+			fmt.Printf("error decrypting aws access key id. details: %s", err)
+			os.Exit(1)
+		}
+		// this environment variable is used by the AWS library, so we neede to set
+		// it again in plain text
+		os.Setenv("AWS_ACCESS_KEY_ID", awsAccessKeyID)
+	}
+
+	awsSecretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	if strings.HasPrefix(awsSecretAccessKey, "encrypted:") {
+		awsSecretAccessKey, err = passwordDecrypt(strings.TrimPrefix(awsSecretAccessKey, "encrypted:"))
+		if err != nil {
+			fmt.Printf("error decrypting aws secret access key. details: %s", err)
+			os.Exit(1)
+		}
+		// this environment variable is used by the AWS library, so we neede to set
+		// it again in plain text
+		os.Setenv("AWS_SECRET_ACCESS_KEY", awsSecretAccessKey)
+	}
+
 	awsSession, err := session.NewSession()
 	if err != nil {
 		log.Printf("error creating aws session. details: %s", err)

--- a/encpass.go
+++ b/encpass.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+)
+
+// passwordKey returns the shared secret used to encrypt and decrypt the
+// passwords. For safety, you should change this numbers before deploying this
+// project. It's importante that the secret has 16 characters, so that we can
+// generate an AES-128.
+func passwordKey() []byte {
+	a0 := []byte{0x90, 0x19, 0x14, 0xa0, 0x94, 0x23, 0xb1, 0xa4, 0x98, 0x27, 0xb5, 0xa8, 0xd3, 0x31, 0xb9, 0xe2}
+	a1 := []byte{0x10, 0x91, 0x20, 0x15, 0xa1, 0x95, 0x24, 0xb2, 0xa5, 0x99, 0x28, 0xb6, 0xa9, 0xd4, 0x32, 0xf1}
+	a2 := []byte{0x12, 0x11, 0x92, 0x21, 0x16, 0xa2, 0x96, 0x25, 0xb3, 0xa6, 0xd1, 0x29, 0xb7, 0xe0, 0xd5, 0x33}
+	a3 := []byte{0x18, 0x13, 0x12, 0x93, 0x22, 0x17, 0xa3, 0x97, 0x26, 0xb4, 0xa7, 0xd2, 0x30, 0xb8, 0xe1, 0xd6}
+
+	result := make([]byte, 16)
+	for i := 0; i < len(result); i++ {
+		result[i] = (((a0[i] & a1[i]) ^ a2[i]) | a3[i])
+	}
+
+	return result
+}
+
+// passwordEncrypt uses the secret to encode the password.
+func passwordEncrypt(input string) (string, error) {
+	block, err := aes.NewCipher(passwordKey())
+	if err != nil {
+		return "", err
+	}
+
+	iv := make([]byte, block.BlockSize())
+	if _, err = rand.Read(iv); err != nil {
+		return "", err
+	}
+
+	output := make([]byte, len(input))
+	ofbStream := cipher.NewOFB(block, iv)
+	ofbStream.XORKeyStream(output, []byte(input))
+
+	buffer := bytes.NewBuffer(iv)
+	buffer.Write(output)
+	return base64.StdEncoding.EncodeToString(buffer.Bytes()), nil
+}
+
+// passwordDecrypt decodes a encrypted password.
+func passwordDecrypt(input string) (string, error) {
+	block, err := aes.NewCipher(passwordKey())
+	if err != nil {
+		return "", err
+	}
+
+	inputBytes, err := base64.StdEncoding.DecodeString(input)
+	if err != nil {
+		return "", err
+	}
+
+	if len(inputBytes) < block.BlockSize() {
+		return "", fmt.Errorf("invalid password size %d", len(inputBytes))
+	}
+
+	iv := inputBytes[:block.BlockSize()]
+	inputBytes = inputBytes[block.BlockSize():]
+
+	output := make([]byte, len(inputBytes))
+	ofbStream := cipher.NewOFB(block, iv)
+	ofbStream.XORKeyStream(output, inputBytes)
+	return string(output), nil
+}


### PR DESCRIPTION
The tool will now allow encrypting values for the environment variables
AWS_ACCOUNT_ID, AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. For backward
compability the tool will only try to decrypt when there's a label prefix
"encrypted:".

Fix #6