### PR TITLE
Remove old local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Subcommands to manage the backups (sync, get, list, remove, start, encrypt)
 - Sensitive parameters can now be encrypted
+- Periodically request remote backups information
 
 ### Fixed
 - Use multipart upload strategy when the archive is bigger than 100MB (was 1GB)
@@ -15,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Major refactory on the project structure, with unit tests and documentation
-- Local storage is synchronized when the remote backup information is requested
+- Local storage is synchronized when the remote backups information is requested
 
 ## [1.0.0] - 2016-12-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Major refactory on the project structure, with unit tests and documentation
+- Local storage is synchronized when the remote backup information is requested
 
 ## [1.0.0] - 2016-12-08
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ follow the AWS suggestion and send multipart when the tarball gets bigger than
 The maximum archive size is 40GB (but we can increase this).
 
 Old backups will also be removed automatically, to avoid keeping many files in
-AWS Glacier service, and consequently saving you some money.
+AWS Glacier service, and consequently saving you some money. Periodically, the
+tool will request the remote backups in AWS to synchronize the local storage.
 
 ## Install
 
@@ -94,7 +95,8 @@ to wait for the iventory).
 When running the scheduler (start command), **the tool will backup the files
 once a day at midnight**. This information isn't configurable yet (the library
 that I'm using for cron tasks isn't so flexible). Also, **old backups are
-removed once a week at 1 AM** (yep, not configurable yet).
+removed once a week at 1 AM** (yep, not configurable yet). To keep the
+consistency, **local storage synchronization will occur once a month at 12 PM**.
 
 A simple shell script that could help you running the program in Unix
 environments:

--- a/toglacier.go
+++ b/toglacier.go
@@ -109,8 +109,9 @@ func main() {
 			Usage: "run the scheduler (will block forever)",
 			Action: func(c *cli.Context) error {
 				scheduler := gocron.NewScheduler()
-				scheduler.Every(1).Day().At("00:00").Do(backup, nil)
-				scheduler.Every(1).Weeks().At("01:00").Do(removeOldBackups, nil)
+				scheduler.Every(1).Day().At("00:00").Do(backup, awsCloud, auditFileStorage)
+				scheduler.Every(1).Weeks().At("01:00").Do(removeOldBackups, awsCloud, auditFileStorage)
+				scheduler.Every(4).Weeks().At("12:00").Do(listBackups, true, awsCloud, auditFileStorage)
 				<-scheduler.Start()
 				return nil
 			},
@@ -232,7 +233,7 @@ func removeBackup(id string, c cloud.Cloud, s storage.Storage) {
 }
 
 func removeOldBackups(c cloud.Cloud, s storage.Storage) {
-	backups := listBackups(true, c, s)
+	backups := listBackups(false, c, s)
 	for i := keepBackups; i < len(backups); i++ {
 		removeBackup(backups[i].ID, c, s)
 	}

--- a/toglacier_test.go
+++ b/toglacier_test.go
@@ -409,6 +409,14 @@ func TestRemoveOldBackups(t *testing.T) {
 			description: "it should remove all old backups correctly",
 			keepBackups: 2,
 			cloud: mockCloud{
+				mockRemove: func(id string) error {
+					if id != "123458" {
+						return fmt.Errorf("unexpected id %s", id)
+					}
+					return nil
+				},
+			},
+			storage: mockStorage{
 				mockList: func() ([]cloud.Backup, error) {
 					return []cloud.Backup{
 						{
@@ -433,37 +441,6 @@ func TestRemoveOldBackups(t *testing.T) {
 				},
 				mockRemove: func(id string) error {
 					if id != "123458" {
-						return fmt.Errorf("unexpected id %s", id)
-					}
-					return nil
-				},
-			},
-			storage: mockStorage{
-				mockSave: func(b cloud.Backup) error {
-					if b.ID != "123456" && b.ID != "123457" && b.ID != "123458" {
-						return fmt.Errorf("adding unexpected id %s", b.ID)
-					}
-
-					return nil
-				},
-				mockList: func() ([]cloud.Backup, error) {
-					return []cloud.Backup{
-						{
-							ID:        "123454",
-							CreatedAt: now.Add(-time.Second),
-							Checksum:  "03c7c9c26fbb71dbc1546fd2fd5f2fbc3f4a410360e8fc016c41593b2456cf59",
-							VaultName: "test",
-						},
-						{
-							ID:        "123455",
-							CreatedAt: now.Add(-time.Minute),
-							Checksum:  "49ddf1762657fa04e29aa8ca6b22a848ce8a9b590748d6d708dd208309bcfee6",
-							VaultName: "test",
-						},
-					}, nil
-				},
-				mockRemove: func(id string) error {
-					if id != "123454" && id != "123455" && id != "123458" {
 						return fmt.Errorf("removing unexpected id %s", id)
 					}
 					return nil


### PR DESCRIPTION
We are not going to request remote backup information only to remove old
backups. But we will periodically (once a month) check the consistency of the
local storage with a new action in the scheduler.

Resolves #17