### PR TITLE
Fix default multipart part size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.0.1] - 2017-03-02
+### Fixed
+- Default multipart part size in bytes
+
 ## [2.0.0] - 2017-02-16
 ### Added
 - Subcommands to manage the backups (sync, get, list, remove, start, encrypt)

--- a/internal/cloud/aws.go
+++ b/internal/cloud/aws.go
@@ -32,12 +32,15 @@ func MultipartUploadLimit(value int64) {
 	atomic.StoreInt64(&multipartUploadLimit, value)
 }
 
-var partSize int64 = 4096 // 4 MB will limit the archive in 40GB
+var partSize int64 = 4194304 // 4 MB will limit the archive in 40GB
 
 // PartSize the size of each part of the multipart upload except the last, in
 // bytes. The last part can be smaller than this part size. By default we use
 // 4MB.
 func PartSize(value int64) {
+	// TODO: Part size must be a power of two and be between 1048576 and
+	// 4294967296 bytes
+
 	atomic.StoreInt64(&partSize, value)
 }
 

--- a/internal/cloud/aws_test.go
+++ b/internal/cloud/aws_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -222,12 +223,23 @@ func TestAWSCloud_Send(t *testing.T) {
 				return f.Name()
 			}(),
 			multipartUploadLimit: 1024,
-			partSize:             100,
+			partSize:             1048576,
 			awsCloud: cloud.AWSCloud{
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: glacierAPIMock{
-					mockInitiateMultipartUpload: func(*glacier.InitiateMultipartUploadInput) (*glacier.InitiateMultipartUploadOutput, error) {
+					mockInitiateMultipartUpload: func(i *glacier.InitiateMultipartUploadInput) (*glacier.InitiateMultipartUploadOutput, error) {
+						partSize, err := strconv.ParseInt(*i.PartSize, 10, 64)
+						if err != nil {
+							return nil, err
+						}
+
+						// Part size must be a power of two and be between 1048576 and
+						// 4294967296 bytes
+						if partSize < 1048576 || partSize > 4294967296 || partSize&(partSize-1) != 0 {
+							return nil, errors.New("Invalid part size")
+						}
+
 						return &glacier.InitiateMultipartUploadOutput{
 							UploadId: aws.String("UPLOAD123"),
 						}, nil


### PR DESCRIPTION
We were using the part size as KB instead of bytes. This was causing an error
while uploading big files.

Resolves #29