### PR TITLE
Hot fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.0.3] - 2017-03-23
+## [2.0.3] - 2017-03-24
 ### Fixed
 - Fix backup removal on checksum mismatch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [2.0.3] - 2017-03-23
+### Fixed
+- Fix backup removal on checksum mismatch
+
+## [2.0.2] - 2017-03-06
 ### Fixed
 - Fix content range format in multipart strategy
 - Fix hash calculation (tree hash) of the uploaded archive

--- a/internal/cloud/aws_test.go
+++ b/internal/cloud/aws_test.go
@@ -454,7 +454,7 @@ func TestAWSCloud_Send(t *testing.T) {
 				VaultName: "vault",
 				Glacier: glacierAPIMock{
 					mockDeleteArchive: func(d *glacier.DeleteArchiveInput) (*glacier.DeleteArchiveOutput, error) {
-						if *d.ArchiveId != "UPLOAD123" {
+						if *d.ArchiveId != "AWSID123" {
 							return nil, fmt.Errorf("unexpected id %s", *d.ArchiveId)
 						}
 
@@ -533,7 +533,7 @@ func TestAWSCloud_Send(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("error comparing checksums. fail to remove backup “UPLOAD123”. details: error removing backup. details: connection error"),
+			expectedError: errors.New("error comparing checksums. fail to remove backup “AWSID123”. details: error removing backup. details: connection error"),
 		},
 	}
 


### PR DESCRIPTION
When the checksum didn't match at the backup upload (multipart strategy), we were trying to remove the strange backup from the cloud using the job ID instead of the backup ID, this would always result in an error (archive not found).