### PR TITLE
Internal log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Encryption data authentication (HMAC-SHA256)
 - Send report with the scheduler actions periodically
 - Output to a log file using logrus library
+- Log verbosity defined in configuration
 
 ### Fixed
 - Add sample configuration file to deb and txz packages

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ configuration file. You can find the configuration file example on
 | TOGLACIER_PATHS                  | Paths to backup (separated by comma)    |
 | TOGLACIER_AUDIT                  | Path where we keep track of the backups |
 | TOGLACIER_LOG_FILE               | File where all events are written       |
+| TOGLACIER_LOG_LEVEL              | Verbosity of the logger                 |
 | TOGLACIER_KEEP_BACKUPS           | Number of backups to keep (default 10)  |
 | TOGLACIER_BACKUP_SECRET          | Encrypt backups with this secret        |
 | TOGLACIER_EMAIL_SERVER           | SMTP server address                     |
@@ -84,7 +85,10 @@ and `Glacier Service`). You will find your AWS region identification
 By default the tool prints everything on the standard output. If you want to
 redirect it to a log file, you can define the location of the file with the
 `TOGLACIER_LOG_FILE`. Even with the output redirection, the messages are still
-writen in the standard output.
+writen in the standard output. You can define the verbosity using the
+`TOGLACIER_LOG_LEVEL` parameter, that can have the values `debug`, `info`,
+`warning`, `error`, `fatal` or `panic`. By default the `error` log level is
+used.
 
 There are some commands in the tool to manage the backups:
 

--- a/internal/archive/ofb_envelop.go
+++ b/internal/archive/ofb_envelop.go
@@ -122,7 +122,7 @@ func (o OFBEnvelop) Encrypt(filename, secret string) (string, error) {
 	}
 
 	o.logger.Debugf("archive: wrote %d bytes to file (encrypted content)", written)
-
+	o.logger.Infof("archive: file “%s” encrypted", filename)
 	return encryptedArchive.Name(), nil
 }
 
@@ -216,6 +216,7 @@ func (o OFBEnvelop) Decrypt(encryptedFilename, secret string) (string, error) {
 		return "", errors.WithStack(newError("", ErrorCodeAuthFailed, nil))
 	}
 
+	o.logger.Infof("archive: file “%s” decrypted", archive.Name())
 	return archive.Name(), nil
 }
 

--- a/internal/archive/tar_builder.go
+++ b/internal/archive/tar_builder.go
@@ -46,7 +46,7 @@ func NewTARBuilder(logger log.Logger) *TARBuilder {
 //       }
 //     }
 func (t TARBuilder) Build(backupPaths ...string) (string, error) {
-	t.logger.Debug("archive: creating tar file in temporary directory")
+	t.logger.Debugf("archive: build tar for backup paths %v", backupPaths)
 
 	tarFile, err := ioutil.TempFile("", "toglacier-")
 	if err != nil {

--- a/internal/archive/tar_builder_test.go
+++ b/internal/archive/tar_builder_test.go
@@ -17,13 +17,19 @@ import (
 func TestTARBuilder_Build(t *testing.T) {
 	scenarios := []struct {
 		description   string
-		builder       archive.TARBuilder
+		builder       *archive.TARBuilder
 		backupPaths   []string
 		expected      func(filename string) error
 		expectedError error
 	}{
 		{
 			description: "it should create an archive correctly from directory path",
+			builder: archive.NewTARBuilder(mockLogger{
+				mockDebug:  func(args ...interface{}) {},
+				mockDebugf: func(format string, args ...interface{}) {},
+				mockInfo:   func(args ...interface{}) {},
+				mockInfof:  func(format string, args ...interface{}) {},
+			}),
 			backupPaths: func() []string {
 				d, err := ioutil.TempDir("", "toglacier-test")
 				if err != nil {
@@ -101,6 +107,12 @@ func TestTARBuilder_Build(t *testing.T) {
 		},
 		{
 			description: "it should create an archive correctly from file path",
+			builder: archive.NewTARBuilder(mockLogger{
+				mockDebug:  func(args ...interface{}) {},
+				mockDebugf: func(format string, args ...interface{}) {},
+				mockInfo:   func(args ...interface{}) {},
+				mockInfof:  func(format string, args ...interface{}) {},
+			}),
 			backupPaths: func() []string {
 				f, err := ioutil.TempFile("", "toglacier-test")
 				if err != nil {
@@ -159,6 +171,12 @@ func TestTARBuilder_Build(t *testing.T) {
 		},
 		{
 			description: "it should detect when the path does not exist",
+			builder: archive.NewTARBuilder(mockLogger{
+				mockDebug:  func(args ...interface{}) {},
+				mockDebugf: func(format string, args ...interface{}) {},
+				mockInfo:   func(args ...interface{}) {},
+				mockInfof:  func(format string, args ...interface{}) {},
+			}),
 			backupPaths: func() []string {
 				return []string{"idontexist12345"}
 			}(),
@@ -174,6 +192,12 @@ func TestTARBuilder_Build(t *testing.T) {
 		},
 		{
 			description: "it should detect when the path (directory) does not have permission",
+			builder: archive.NewTARBuilder(mockLogger{
+				mockDebug:  func(args ...interface{}) {},
+				mockDebugf: func(format string, args ...interface{}) {},
+				mockInfo:   func(args ...interface{}) {},
+				mockInfof:  func(format string, args ...interface{}) {},
+			}),
 			backupPaths: func() []string {
 				n := path.Join(os.TempDir(), "toglacier-test-archive-dir-noperm")
 				if _, err := os.Stat(n); os.IsNotExist(err) {
@@ -197,6 +221,12 @@ func TestTARBuilder_Build(t *testing.T) {
 		},
 		{
 			description: "it should detect when the path (file) does not have permission",
+			builder: archive.NewTARBuilder(mockLogger{
+				mockDebug:  func(args ...interface{}) {},
+				mockDebugf: func(format string, args ...interface{}) {},
+				mockInfo:   func(args ...interface{}) {},
+				mockInfof:  func(format string, args ...interface{}) {},
+			}),
 			backupPaths: func() []string {
 				n := path.Join(os.TempDir(), "toglacier-test-archive-file-noperm")
 				if _, err := os.Stat(n); os.IsNotExist(err) {
@@ -223,6 +253,12 @@ func TestTARBuilder_Build(t *testing.T) {
 		},
 		{
 			description: "it should detect an error while walking in the path",
+			builder: archive.NewTARBuilder(mockLogger{
+				mockDebug:  func(args ...interface{}) {},
+				mockDebugf: func(format string, args ...interface{}) {},
+				mockInfo:   func(args ...interface{}) {},
+				mockInfof:  func(format string, args ...interface{}) {},
+			}),
 			backupPaths: func() []string {
 				n := path.Join(os.TempDir(), "toglacier-test-archive-dir-file-noperm")
 				if _, err := os.Stat(n); os.IsNotExist(err) {
@@ -270,22 +306,22 @@ func TestTARBuilder_Build(t *testing.T) {
 	}
 }
 
-type mockLog struct {
+type mockLogger struct {
 	mockDebug  func(args ...interface{})
 	mockDebugf func(format string, args ...interface{})
 	mockInfo   func(args ...interface{})
 	mockInfof  func(format string, args ...interface{})
 }
 
-func (m mockLog) Debug(args ...interface{}) {
+func (m mockLogger) Debug(args ...interface{}) {
 	m.mockDebug(args...)
 }
-func (m mockLog) Debugf(format string, args ...interface{}) {
+func (m mockLogger) Debugf(format string, args ...interface{}) {
 	m.mockDebugf(format, args...)
 }
-func (m mockLog) Info(args ...interface{}) {
+func (m mockLogger) Info(args ...interface{}) {
 	m.mockInfo(args...)
 }
-func (m mockLog) Infof(format string, args ...interface{}) {
+func (m mockLogger) Infof(format string, args ...interface{}) {
 	m.mockInfof(format, args...)
 }

--- a/internal/cloud/aws.go
+++ b/internal/cloud/aws.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/glacier/glacieriface"
 	"github.com/pkg/errors"
 	"github.com/rafaeljusto/toglacier/internal/config"
+	"github.com/rafaeljusto/toglacier/internal/log"
 )
 
 var multipartUploadLimit int64 = 102400 // 100 MB
@@ -63,6 +64,7 @@ func WaitJobTime(value time.Duration) {
 // AWSCloud is the Amazon solution for storing the backups in the cloud. It uses
 // the Amazon Glacier service, as it allows large files for a small price.
 type AWSCloud struct {
+	Logger    log.Logger
 	AccountID string
 	VaultName string
 	Glacier   glacieriface.GlacierAPI
@@ -87,7 +89,7 @@ type AWSCloud struct {
 //         // unknown error
 //       }
 //     }
-func NewAWSCloud(c *config.Config, debug bool) (*AWSCloud, error) {
+func NewAWSCloud(logger log.Logger, c *config.Config, debug bool) (*AWSCloud, error) {
 	var err error
 
 	// this environment variables are used by the AWS library, so we need to set
@@ -107,6 +109,7 @@ func NewAWSCloud(c *config.Config, debug bool) (*AWSCloud, error) {
 	}
 
 	return &AWSCloud{
+		Logger:    logger,
 		AccountID: c.AWS.AccountID.Value,
 		VaultName: c.AWS.VaultName,
 		Glacier:   awsGlacier,
@@ -135,6 +138,8 @@ func NewAWSCloud(c *config.Config, debug bool) (*AWSCloud, error) {
 //       }
 //     }
 func (a *AWSCloud) Send(filename string) (Backup, error) {
+	a.Logger.Debugf("[cloud] sending file “%s” to aws cloud", filename)
+
 	archive, err := os.Open(filename)
 	if err != nil {
 		return Backup{}, errors.WithStack(newError("", ErrorCodeOpeningArchive, err))
@@ -146,9 +151,11 @@ func (a *AWSCloud) Send(filename string) (Backup, error) {
 	}
 
 	if archiveInfo.Size() <= multipartUploadLimit {
+		a.Logger.Debugf("[cloud] using small file strategy (%d)", archiveInfo.Size())
 		return a.sendSmall(archive)
 	}
 
+	a.Logger.Debugf("[cloud] using big file strategy (%d)", archiveInfo.Size())
 	return a.sendBig(archive, archiveInfo.Size())
 }
 
@@ -175,6 +182,7 @@ func (a *AWSCloud) sendSmall(archive *os.File) (Backup, error) {
 	}
 
 	if hex.EncodeToString(hash.TreeHash) != *archiveCreationOutput.Checksum {
+		a.Logger.Debugf("[cloud] local archive checksum (%s) different from remote checksum (%s)", hex.EncodeToString(hash.TreeHash), *archiveCreationOutput.Checksum)
 		return Backup{}, errors.WithStack(newError("", ErrorCodeComparingChecksums, nil))
 	}
 
@@ -206,6 +214,8 @@ func (a *AWSCloud) sendBig(archive *os.File, archiveSize int64) (Backup, error) 
 	var part = make([]byte, partSize)
 
 	for offset = 0; offset < archiveSize; offset += partSize {
+		a.Logger.Debugf("[cloud] sending part %d/%d", offset, archiveSize)
+
 		n, err := archive.Read(part)
 		if err != nil {
 			return Backup{}, errors.WithStack(newMultipartError(offset, archiveSize, MultipartErrorCodeReadingArchive, err))
@@ -237,6 +247,8 @@ func (a *AWSCloud) sendBig(archive *os.File, archiveSize int64) (Backup, error) 
 
 		// verify checksum of each uploaded part
 		if *uploadMultipartPartOutput.Checksum != hex.EncodeToString(hash.TreeHash) {
+			a.Logger.Debugf("[cloud] local archive part %d/%d checksum (%s) different from remote checksum (%s)", offset, archiveSize, hex.EncodeToString(hash.TreeHash), *uploadMultipartPartOutput.Checksum)
+
 			abortMultipartUploadInput := glacier.AbortMultipartUploadInput{
 				AccountId: aws.String(a.AccountID),
 				UploadId:  initiateMultipartUploadOutput.UploadId,
@@ -278,6 +290,8 @@ func (a *AWSCloud) sendBig(archive *os.File, archiveSize int64) (Backup, error) 
 	backup.VaultName = a.VaultName
 
 	if hex.EncodeToString(hash.TreeHash) != *archiveCreationOutput.Checksum {
+		a.Logger.Debugf("[cloud] local archive checksum (%s) different from remote checksum (%s)", hex.EncodeToString(hash.TreeHash), *archiveCreationOutput.Checksum)
+
 		// something went wrong with the uploaded archive, better remove it
 		if err := a.Remove(backup.ID); err != nil {
 			// error while trying to remove the strange backup
@@ -308,6 +322,8 @@ func (a *AWSCloud) sendBig(archive *os.File, archiveSize int64) (Backup, error) 
 //       }
 //     }
 func (a *AWSCloud) List() ([]Backup, error) {
+	a.Logger.Debug("[cloud] retrieving list of archives from the aws cloud")
+
 	initiateJobInput := glacier.InitiateJobInput{
 		AccountId: aws.String(a.AccountID),
 		JobParameters: &glacier.JobParameters{
@@ -382,6 +398,8 @@ func (a *AWSCloud) List() ([]Backup, error) {
 //       }
 //     }
 func (a *AWSCloud) Get(id string) (string, error) {
+	a.Logger.Debugf("[cloud] retrieving archive %s from the aws cloud", id)
+
 	initiateJobInput := glacier.InitiateJobInput{
 		AccountId: aws.String(a.AccountID),
 		JobParameters: &glacier.JobParameters{
@@ -442,6 +460,8 @@ func (a *AWSCloud) Get(id string) (string, error) {
 //       }
 //     }
 func (a *AWSCloud) Remove(id string) error {
+	a.Logger.Debugf("[cloud] removing archive %s from the aws cloud", id)
+
 	deleteArchiveInput := glacier.DeleteArchiveInput{
 		AccountId: aws.String(a.AccountID),
 		ArchiveId: aws.String(id),
@@ -456,6 +476,8 @@ func (a *AWSCloud) Remove(id string) error {
 }
 
 func (a *AWSCloud) waitJob(jobID string) error {
+	a.Logger.Debugf("[cloud] waiting for job %s", jobID)
+
 	waitJobTime.RLock()
 	sleep := waitJobTime.Duration
 	waitJobTime.RUnlock()
@@ -496,6 +518,7 @@ func (a *AWSCloud) waitJob(jobID string) error {
 			return errors.WithStack(newError(jobID, ErrorCodeJobNotFound, nil))
 		}
 
+		a.Logger.Debugf("[cloud] job %s not done, waiting %s for next check", jobID, sleep.String())
 		time.Sleep(sleep)
 	}
 }

--- a/internal/cloud/aws_test.go
+++ b/internal/cloud/aws_test.go
@@ -23,11 +23,13 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/rafaeljusto/toglacier/internal/cloud"
 	"github.com/rafaeljusto/toglacier/internal/config"
+	"github.com/rafaeljusto/toglacier/internal/log"
 )
 
 func TestNewAWSCloud(t *testing.T) {
 	scenarios := []struct {
 		description   string
+		logger        log.Logger
 		config        *config.Config
 		debug         bool
 		expected      *cloud.AWSCloud
@@ -62,7 +64,7 @@ func TestNewAWSCloud(t *testing.T) {
 		t.Run(scenario.description, func(t *testing.T) {
 			os.Clearenv()
 
-			awsCloud, err := cloud.NewAWSCloud(scenario.config, scenario.debug)
+			awsCloud, err := cloud.NewAWSCloud(scenario.logger, scenario.config, scenario.debug)
 
 			// we are not interested on testing low level structures from AWS library
 			// or clock controlling layer
@@ -105,6 +107,14 @@ func TestAWSCloud_Send(t *testing.T) {
 			filename:             "toglacier-idontexist.tmp",
 			multipartUploadLimit: 102400,
 			partSize:             4096,
+			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
+			},
 			expectedError: &cloud.Error{
 				Code: cloud.ErrorCodeOpeningArchive,
 				Err: &os.PathError{
@@ -129,6 +139,12 @@ func TestAWSCloud_Send(t *testing.T) {
 			multipartUploadLimit: 102400,
 			partSize:             4096,
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -168,6 +184,12 @@ func TestAWSCloud_Send(t *testing.T) {
 			multipartUploadLimit: 102400,
 			partSize:             4096,
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -201,6 +223,12 @@ func TestAWSCloud_Send(t *testing.T) {
 			multipartUploadLimit: 102400,
 			partSize:             4096,
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -237,6 +265,12 @@ func TestAWSCloud_Send(t *testing.T) {
 			multipartUploadLimit: 1024,
 			partSize:             1048576,
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -298,6 +332,12 @@ func TestAWSCloud_Send(t *testing.T) {
 			multipartUploadLimit: 1024,
 			partSize:             100,
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -331,6 +371,12 @@ func TestAWSCloud_Send(t *testing.T) {
 			multipartUploadLimit: 1024,
 			partSize:             100,
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -385,6 +431,12 @@ func TestAWSCloud_Send(t *testing.T) {
 			multipartUploadLimit: 1024,
 			partSize:             100,
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -429,6 +481,12 @@ func TestAWSCloud_Send(t *testing.T) {
 			multipartUploadLimit: 1024,
 			partSize:             100,
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -477,6 +535,12 @@ func TestAWSCloud_Send(t *testing.T) {
 			multipartUploadLimit: 1024,
 			partSize:             100,
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -538,6 +602,12 @@ func TestAWSCloud_Send(t *testing.T) {
 			multipartUploadLimit: 1024,
 			partSize:             100,
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -616,6 +686,12 @@ func TestAWSCloud_List(t *testing.T) {
 		{
 			description: "it should list all backups correctly",
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -688,6 +764,12 @@ func TestAWSCloud_List(t *testing.T) {
 		{
 			description: "it should detect an error while initiating the job",
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -704,6 +786,12 @@ func TestAWSCloud_List(t *testing.T) {
 		{
 			description: "it should detect when there's an error listing the existing jobs",
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -726,6 +814,12 @@ func TestAWSCloud_List(t *testing.T) {
 		{
 			description: "it should detect when the job failed",
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -757,6 +851,12 @@ func TestAWSCloud_List(t *testing.T) {
 		{
 			description: "it should detect when the job was not found",
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -786,6 +886,12 @@ func TestAWSCloud_List(t *testing.T) {
 		{
 			description: "it should continue checking jobs until it completes",
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -849,6 +955,12 @@ func TestAWSCloud_List(t *testing.T) {
 		{
 			description: "it should detect an error while retrieving the job data",
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -882,6 +994,12 @@ func TestAWSCloud_List(t *testing.T) {
 		{
 			description: "it should detect an error while decoding the job data",
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -946,6 +1064,12 @@ func TestAWSCloud_Get(t *testing.T) {
 			description: "it should retrieve a backup correctly",
 			id:          "AWSID123",
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -978,6 +1102,12 @@ func TestAWSCloud_Get(t *testing.T) {
 			description: "it should detect an error while initiating the job",
 			id:          "AWSID123",
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -996,6 +1126,12 @@ func TestAWSCloud_Get(t *testing.T) {
 			description: "it should detect when there's an error listing the existing jobs",
 			id:          "AWSID123",
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -1019,6 +1155,12 @@ func TestAWSCloud_Get(t *testing.T) {
 			description: "it should detect when the job failed",
 			id:          "AWSID123",
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -1051,6 +1193,12 @@ func TestAWSCloud_Get(t *testing.T) {
 			description: "it should detect when the job was not found",
 			id:          "AWSID123",
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -1081,6 +1229,12 @@ func TestAWSCloud_Get(t *testing.T) {
 			description: "it should continue checking jobs until it completes",
 			id:          "AWSID123",
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -1117,6 +1271,12 @@ func TestAWSCloud_Get(t *testing.T) {
 			description: "it should detect an error while retrieving the job data",
 			id:          "AWSID123",
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -1173,6 +1333,12 @@ func TestAWSCloud_Remove(t *testing.T) {
 			description: "it should remove a backup correctly",
 			id:          "AWSID123",
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -1186,6 +1352,12 @@ func TestAWSCloud_Remove(t *testing.T) {
 			description: "it should detect an error while removing a backup",
 			id:          "AWSID123",
 			awsCloud: cloud.AWSCloud{
+				Logger: mockLogger{
+					mockDebug:  func(args ...interface{}) {},
+					mockDebugf: func(format string, args ...interface{}) {},
+					mockInfo:   func(args ...interface{}) {},
+					mockInfof:  func(format string, args ...interface{}) {},
+				},
 				AccountID: "account",
 				VaultName: "vault",
 				Glacier: mockGlacierAPI{
@@ -1569,6 +1741,26 @@ type mockReader struct {
 
 func (m mockReader) Read(p []byte) (n int, err error) {
 	return m.mockRead(p)
+}
+
+type mockLogger struct {
+	mockDebug  func(args ...interface{})
+	mockDebugf func(format string, args ...interface{})
+	mockInfo   func(args ...interface{})
+	mockInfof  func(format string, args ...interface{})
+}
+
+func (m mockLogger) Debug(args ...interface{}) {
+	m.mockDebug(args...)
+}
+func (m mockLogger) Debugf(format string, args ...interface{}) {
+	m.mockDebugf(format, args...)
+}
+func (m mockLogger) Info(args ...interface{}) {
+	m.mockInfo(args...)
+}
+func (m mockLogger) Infof(format string, args ...interface{}) {
+	m.mockInfof(format, args...)
 }
 
 // Diff is useful to see the difference when comparing two complex types.

--- a/internal/config/error.go
+++ b/internal/config/error.go
@@ -30,6 +30,10 @@ const (
 
 	// ErrorCodeFillingIV error while filling the IV array with random bytes.
 	ErrorCodeFillingIV ErrorCode = "filling-iv"
+
+	// ErrorCodeLogLevel informed log level is unknown, it should be "debug",
+	// "info", "warning", "error", "fatal" or "panic".
+	ErrorCodeLogLevel ErrorCode = "log-level"
 )
 
 // ErrorCode stores the error type that occurred while reading
@@ -53,6 +57,8 @@ func (e ErrorCode) String() string {
 		return "invalid password size"
 	case ErrorCodeFillingIV:
 		return "error filling iv"
+	case ErrorCodeLogLevel:
+		return "invalid log level"
 	}
 
 	return "unknown error code"

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,0 +1,11 @@
+// Package log defines an interface for the library be able to log what is
+// happening on each stage.
+package log
+
+// Logger contains all log actions that the library can do.
+type Logger interface {
+	Debug(args ...interface{})
+	Debugf(format string, args ...interface{})
+	Info(args ...interface{})
+	Infof(format string, args ...interface{})
+}

--- a/toglacier.go
+++ b/toglacier.go
@@ -67,9 +67,9 @@ func main() {
 
 		// optionally set logger output file defined in configuration. if not
 		// defined stdout will be used
-		if config.Current().LogFile != "" {
-			if logFile, err = os.OpenFile(config.Current().LogFile, os.O_CREATE|os.O_WRONLY, os.ModePerm); err != nil {
-				fmt.Printf("error opening log file “%s”. details: %s\n", config.Current().LogFile, err)
+		if config.Current().Log.File != "" {
+			if logFile, err = os.OpenFile(config.Current().Log.File, os.O_CREATE|os.O_WRONLY, os.ModePerm); err != nil {
+				fmt.Printf("error opening log file “%s”. details: %s\n", config.Current().Log.File, err)
 				return err
 			}
 
@@ -77,7 +77,22 @@ func main() {
 			logger.Out = io.MultiWriter(os.Stdout, logFile)
 		}
 
-		tarBuilder = archive.NewTARBuilder()
+		switch config.Current().Log.Level {
+		case config.LogLevelDebug:
+			logger.Level = logrus.DebugLevel
+		case config.LogLevelInfo:
+			logger.Level = logrus.InfoLevel
+		case config.LogLevelWarning:
+			logger.Level = logrus.WarnLevel
+		case config.LogLevelError:
+			logger.Level = logrus.ErrorLevel
+		case config.LogLevelFatal:
+			logger.Level = logrus.FatalLevel
+		case config.LogLevelPanic:
+			logger.Level = logrus.PanicLevel
+		}
+
+		tarBuilder = archive.NewTARBuilder(logger)
 		ofbEnvelop = archive.NewOFBEnvelop()
 
 		if awsCloud, err = cloud.NewAWSCloud(config.Current(), false); err != nil {

--- a/toglacier.go
+++ b/toglacier.go
@@ -95,7 +95,7 @@ func main() {
 		tarBuilder = archive.NewTARBuilder(logger)
 		ofbEnvelop = archive.NewOFBEnvelop(logger)
 
-		if awsCloud, err = cloud.NewAWSCloud(config.Current(), false); err != nil {
+		if awsCloud, err = cloud.NewAWSCloud(logger, config.Current(), false); err != nil {
 			fmt.Printf("error initializing AWS cloud. details: %s\n", err)
 			return err
 		}

--- a/toglacier.go
+++ b/toglacier.go
@@ -93,7 +93,7 @@ func main() {
 		}
 
 		tarBuilder = archive.NewTARBuilder(logger)
-		ofbEnvelop = archive.NewOFBEnvelop()
+		ofbEnvelop = archive.NewOFBEnvelop(logger)
 
 		if awsCloud, err = cloud.NewAWSCloud(config.Current(), false); err != nil {
 			fmt.Printf("error initializing AWS cloud. details: %s\n", err)

--- a/toglacier.go
+++ b/toglacier.go
@@ -100,7 +100,7 @@ func main() {
 			return err
 		}
 
-		auditFileStorage = storage.NewAuditFile(config.Current().AuditFile)
+		auditFileStorage = storage.NewAuditFile(logger, config.Current().AuditFile)
 		return nil
 	}
 	app.Commands = []cli.Command{

--- a/toglacier.yml
+++ b/toglacier.yml
@@ -2,7 +2,9 @@ paths:
   - /usr/local/important-files-1
   - /usr/local/important-files-2
 audit file: /var/log/toglacier/audit.log
-log file: /var/log/toglacier/toglacier.log
+log:
+  file: /var/log/toglacier/toglacier.log
+  level: error
 keep backups: 10
 backup secret: encrypted:/lFK9sxAXAL8CuM1GYwGsdj4UJQYEQ==
 email:


### PR DESCRIPTION
Add log entries to all internal packages. This is useful for debugging and understanding all the stages performed.

See #41 