### PR TITLE
Detect ransomware infection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Option to ignore backup parts from files that didn't change in disk
 - Download many archives in parallel
 - Using context from AWS library for user cancellation
+- Detect ransomware infection (maximum number of modified files)
 
 ### Fixed
 - Ignore unmodified files when choosing the backup parts to download

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Some cool features that you will find in this tool:
 
   * Backup the desired directories periodically;
   * Upload only modified files (small backups parts);
+  * Detect ransomware infection (too many modified files);
   * Encrypt backups before sending to the cloud;
   * Automatically download and rebuild backup parts;
   * Old backups are removed periodically to save you some money;
@@ -87,6 +88,7 @@ configuration file. You can find the configuration file example on
 | TOGLACIER_LOG_LEVEL              | Verbosity of the logger                 |
 | TOGLACIER_KEEP_BACKUPS           | Number of backups to keep (default 10)  |
 | TOGLACIER_BACKUP_SECRET          | Encrypt backups with this secret        |
+| TOGLACIER_MODIFY_TOLERANCE       | Maximum percentage of modified files    |
 | TOGLACIER_EMAIL_SERVER           | SMTP server address                     |
 | TOGLACIER_EMAIL_PORT             | SMTP server port                        |
 | TOGLACIER_EMAIL_USERNAME         | Username for e-mail authentication      |
@@ -160,6 +162,7 @@ TOGLACIER_LOG_FILE="/var/log/toglacier/toglacier.log" \
 TOGLACIER_LOG_LEVEL="error" \
 TOGLACIER_KEEP_BACKUPS="10" \
 TOGLACIER_BACKUP_SECRET="encrypted:/lFK9sxAXAL8CuM1GYwGsdj4UJQYEQ==" \
+TOGLACIER_MODIFY_TOLERANCE="90%" \
 TOGLACIER_EMAIL_SERVER="smtp.example.com" \
 TOGLACIER_EMAIL_PORT="587" \
 TOGLACIER_EMAIL_USERNAME="user@example.com" \
@@ -223,6 +226,7 @@ c:\> nssm.exe set toglacier AppEnvironmentExtra ^
   TOGLACIER_LOG_LEVEL=error ^
   TOGLACIER_KEEP_BACKUPS=10 ^
   TOGLACIER_BACKUP_SECRET=encrypted:/lFK9sxAXAL8CuM1GYwGsdj4UJQYEQ== ^
+  TOGLACIER_MODIFY_TOLERANCE=90% ^
   TOGLACIER_EMAIL_SERVER=smtp.example.com ^
   TOGLACIER_EMAIL_PORT=587 ^
   TOGLACIER_EMAIL_USERNAME=user@example.com ^

--- a/cmd/toglacier/toglacier.go
+++ b/cmd/toglacier/toglacier.go
@@ -224,7 +224,7 @@ func commandSync(c *cli.Context) error {
 		logger.Out = ioutil.Discard
 	}
 
-	if err := toGlacier.Backup(config.Current().Paths, config.Current().BackupSecret.Value); err != nil {
+	if err := toGlacier.Backup(config.Current().Paths, config.Current().BackupSecret.Value, float64(config.Current().ModifyTolerance)); err != nil {
 		logger.Error(err)
 	}
 
@@ -305,7 +305,7 @@ func commandList(c *cli.Context) error {
 func commandStart(c *cli.Context) error {
 	scheduler := gocron.NewScheduler()
 	scheduler.Every(1).Day().At("00:00").Do(func() {
-		if err := toGlacier.Backup(config.Current().Paths, config.Current().BackupSecret.Value); err != nil {
+		if err := toGlacier.Backup(config.Current().Paths, config.Current().BackupSecret.Value, float64(config.Current().ModifyTolerance)); err != nil {
 			logger.Error(err)
 		}
 	})

--- a/cmd/toglacier/toglacier.yml
+++ b/cmd/toglacier/toglacier.yml
@@ -9,6 +9,7 @@ log:
   level: error
 keep backups: 10
 backup secret: encrypted:/lFK9sxAXAL8CuM1GYwGsdj4UJQYEQ==
+modify tolerance: 90.0
 email:
   server: smtp.example.com
   port: 587

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,2 @@
+// Package toglacier have all the functions to manage your backups in the cloud.
+package toglacier

--- a/error.go
+++ b/error.go
@@ -1,0 +1,93 @@
+package toglacier
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	// ErrorCodeModifyTolerance error when too many files were modified between
+	// backups. This is an alert for ransomware infection.
+	ErrorCodeModifyTolerance ErrorCode = "modify-tolerance"
+)
+
+// ErrorCode stores the error type that occurred while processing commands from
+// toglacier.
+type ErrorCode string
+
+// String translate the error code to a human readable text.
+func (e ErrorCode) String() string {
+	switch e {
+	case ErrorCodeModifyTolerance:
+		return "too many files modified, aborting for precaution"
+	}
+
+	return "unknown error code"
+}
+
+// Error stores error details from a problem occurred while executing high level
+// commands from toglacier.
+type Error struct {
+	Paths []string
+	Code  ErrorCode
+	Err   error
+}
+
+func newError(paths []string, code ErrorCode, err error) *Error {
+	return &Error{
+		Paths: paths,
+		Code:  code,
+		Err:   errors.WithStack(err),
+	}
+}
+
+// Error returns the error in a human readable format.
+func (e Error) Error() string {
+	return e.String()
+}
+
+// String translate the error to a human readable text.
+func (e Error) String() string {
+	var paths string
+	if e.Paths != nil {
+		paths = fmt.Sprintf("paths [%s], ", strings.Join(e.Paths, ", "))
+	}
+
+	var err string
+	if e.Err != nil {
+		err = fmt.Sprintf(". details: %s", e.Err)
+	}
+
+	return fmt.Sprintf("toglacier: %s%s%s", paths, e.Code, err)
+}
+
+// ErrorEqual compares two Error objects. This is useful to compare down to the
+// low level errors.
+func ErrorEqual(first, second error) bool {
+	if first == nil || second == nil {
+		return first == second
+	}
+
+	err1, ok1 := errors.Cause(first).(*Error)
+	err2, ok2 := errors.Cause(second).(*Error)
+
+	if !ok1 || !ok2 {
+		return false
+	}
+
+	if !reflect.DeepEqual(err1.Paths, err2.Paths) || err1.Code != err2.Code {
+		return false
+	}
+
+	errCause1 := errors.Cause(err1.Err)
+	errCause2 := errors.Cause(err2.Err)
+
+	if errCause1 == nil || errCause2 == nil {
+		return errCause1 == errCause2
+	}
+
+	return errCause1.Error() == errCause2.Error()
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,182 @@
+package toglacier_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/rafaeljusto/toglacier"
+)
+
+func TestError_Error(t *testing.T) {
+	scenarios := []struct {
+		description string
+		err         *toglacier.Error
+		expected    string
+	}{
+		{
+			description: "it should show the message with paths and low level error",
+			err: &toglacier.Error{
+				Paths: []string{"/path1/important", "/path2/also-important"},
+				Code:  toglacier.ErrorCodeModifyTolerance,
+				Err:   errors.New("low level error"),
+			},
+			expected: "toglacier: paths [/path1/important, /path2/also-important], too many files modified, aborting for precaution. details: low level error",
+		},
+		{
+			description: "it should show the message only with the paths",
+			err: &toglacier.Error{
+				Paths: []string{"/path1/important", "/path2/also-important"},
+				Code:  toglacier.ErrorCodeModifyTolerance,
+			},
+			expected: "toglacier: paths [/path1/important, /path2/also-important], too many files modified, aborting for precaution",
+		},
+		{
+			description: "it should show the message only with the low level error",
+			err: &toglacier.Error{
+				Code: toglacier.ErrorCodeModifyTolerance,
+				Err:  errors.New("low level error"),
+			},
+			expected: "toglacier: too many files modified, aborting for precaution. details: low level error",
+		},
+		{
+			description: "it should show the correct error message for too many modified files",
+			err:         &toglacier.Error{Code: toglacier.ErrorCodeModifyTolerance},
+			expected:    "toglacier: too many files modified, aborting for precaution",
+		},
+		{
+			description: "it should detect when the code doesn't exist",
+			err:         &toglacier.Error{Code: toglacier.ErrorCode("i-dont-exist")},
+			expected:    "toglacier: unknown error code",
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.description, func(t *testing.T) {
+			if msg := scenario.err.Error(); msg != scenario.expected {
+				t.Errorf("errors don't match. expected “%s” and got “%s”", scenario.expected, msg)
+			}
+		})
+	}
+}
+
+func TestErrorEqual(t *testing.T) {
+	scenarios := []struct {
+		description string
+		err1        error
+		err2        error
+		expected    bool
+	}{
+		{
+			description: "it should detect equal Error instances",
+			err1: &toglacier.Error{
+				Paths: []string{"/path1/important", "/path2/also-important"},
+				Code:  toglacier.ErrorCodeModifyTolerance,
+				Err:   errors.New("low level error"),
+			},
+			err2: &toglacier.Error{
+				Paths: []string{"/path1/important", "/path2/also-important"},
+				Code:  toglacier.ErrorCodeModifyTolerance,
+				Err:   errors.New("low level error"),
+			},
+			expected: true,
+		},
+		{
+			description: "it should detect when the paths is different",
+			err1: &toglacier.Error{
+				Paths: []string{"/path1/important"},
+				Code:  toglacier.ErrorCodeModifyTolerance,
+				Err:   errors.New("low level error"),
+			},
+			err2: &toglacier.Error{
+				Paths: []string{"/path2/important"},
+				Code:  toglacier.ErrorCodeModifyTolerance,
+				Err:   errors.New("low level error"),
+			},
+			expected: false,
+		},
+		{
+			description: "it should detect when the code is different",
+			err1: &toglacier.Error{
+				Paths: []string{"/path1/important", "/path2/also-important"},
+				Code:  toglacier.ErrorCodeModifyTolerance,
+				Err:   errors.New("low level error"),
+			},
+			err2: &toglacier.Error{
+				Paths: []string{"/path1/important", "/path2/also-important"},
+				Code:  toglacier.ErrorCode("some-another-error"),
+				Err:   errors.New("low level error"),
+			},
+			expected: false,
+		},
+		{
+			description: "it should detect when the low level error is different",
+			err1: &toglacier.Error{
+				Paths: []string{"/path1/important", "/path2/also-important"},
+				Code:  toglacier.ErrorCodeModifyTolerance,
+				Err:   errors.New("low level error 1"),
+			},
+			err2: &toglacier.Error{
+				Paths: []string{"/path1/important", "/path2/also-important"},
+				Code:  toglacier.ErrorCodeModifyTolerance,
+				Err:   errors.New("low level error 2"),
+			},
+			expected: false,
+		},
+		{
+			description: "it should detect when both errors are undefined",
+			expected:    true,
+		},
+		{
+			description: "it should detect when only one error is undefined",
+			err1: &toglacier.Error{
+				Paths: []string{"/path1/important", "/path2/also-important"},
+				Code:  toglacier.ErrorCodeModifyTolerance,
+				Err:   errors.New("low level error"),
+			},
+			expected: false,
+		},
+		{
+			description: "it should detect when both causes of the error are undefined",
+			err1: &toglacier.Error{
+				Paths: []string{"/path1/important", "/path2/also-important"},
+				Code:  toglacier.ErrorCodeModifyTolerance,
+			},
+			err2: &toglacier.Error{
+				Paths: []string{"/path1/important", "/path2/also-important"},
+				Code:  toglacier.ErrorCodeModifyTolerance,
+			},
+			expected: true,
+		},
+		{
+			description: "it should detect when only one causes of the error is undefined",
+			err1: &toglacier.Error{
+				Paths: []string{"/path1/important", "/path2/also-important"},
+				Code:  toglacier.ErrorCodeModifyTolerance,
+				Err:   errors.New("low level error"),
+			},
+			err2: &toglacier.Error{
+				Paths: []string{"/path1/important", "/path2/also-important"},
+				Code:  toglacier.ErrorCodeModifyTolerance,
+			},
+			expected: false,
+		},
+		{
+			description: "it should detect when one the error isn't Error type",
+			err1: &toglacier.Error{
+				Paths: []string{"/path1/important", "/path2/also-important"},
+				Code:  toglacier.ErrorCodeModifyTolerance,
+				Err:   errors.New("low level error"),
+			},
+			err2:     errors.New("low level error"),
+			expected: false,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.description, func(t *testing.T) {
+			if equal := toglacier.ErrorEqual(scenario.err1, scenario.err2); equal != scenario.expected {
+				t.Errorf("results don't match. expected “%t” and got “%t”", scenario.expected, equal)
+			}
+		})
+	}
+}

--- a/internal/config/error.go
+++ b/internal/config/error.go
@@ -42,6 +42,12 @@ const (
 	// ErrorCodeEmailFormat informed email format is unknown, it should be "plain"
 	// or "html".
 	ErrorCodeEmailFormat ErrorCode = "email-format"
+
+	// ErrorCodePercentageFormat invalid percentage format.
+	ErrorCodePercentageFormat ErrorCode = "percentage-format"
+
+	// ErrorCodePercentageRange percentage must be between 0 and 100.
+	ErrorCodePercentageRange ErrorCode = "percentage-range"
 )
 
 // ErrorCode stores the error type that occurred while reading
@@ -71,6 +77,10 @@ func (e ErrorCode) String() string {
 		return "invalid log level"
 	case ErrorCodeEmailFormat:
 		return "invalid email format"
+	case ErrorCodePercentageFormat:
+		return "invalid percentage format"
+	case ErrorCodePercentageRange:
+		return "invalid percentage range"
 	}
 
 	return "unknown error code"

--- a/internal/config/error_test.go
+++ b/internal/config/error_test.go
@@ -89,6 +89,16 @@ func TestError_Error(t *testing.T) {
 			expected:    "config: invalid email format",
 		},
 		{
+			description: "it should show the correct error message for invalid percentage format",
+			err:         &config.Error{Code: config.ErrorCodePercentageFormat},
+			expected:    "config: invalid percentage format",
+		},
+		{
+			description: "it should show the correct error message for invalid percentage range",
+			err:         &config.Error{Code: config.ErrorCodePercentageRange},
+			expected:    "config: invalid percentage range",
+		},
+		{
 			description: "it should detect when the code doesn't exist",
 			err:         &config.Error{Code: config.ErrorCode("i-dont-exist")},
 			expected:    "config: unknown error code",


### PR DESCRIPTION
When there're too many files modified between two backups, we should raise an
alert and avoid sending a probably infected backup to the cloud.

Resolves #67